### PR TITLE
Project List: Show progress bar while projects are loading

### DIFF
--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.html
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.html
@@ -8,6 +8,7 @@
   <app-search-field
     [label]="'dmp.steps.project.search' | translate"
     (searchChange)="search($event)"></app-search-field>
+  <mat-progress-bar *ngIf="loading" mode="indeterminate"></mat-progress-bar>
   <div class="list-container" *ngIf="!selectedProject">
     <mat-selection-list
       hideSingleSelectionIndicator

--- a/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
+++ b/libs/damap/src/lib/components/dmp/project/project-list/project-list.component.ts
@@ -45,6 +45,7 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
 
   private searchTerms = new Subject<string>();
   searchResult$: Observable<SearchResult<Project>>;
+  loading = false;
 
   constructor(
     private backendService: BackendService,
@@ -68,7 +69,10 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
             : this.backendService.getProjectSearchResult(term),
         ),
       )
-      .subscribe(results => (this.searchResult$ = of(results)));
+      .subscribe(results => {
+        this.loading = false;
+        this.searchResult$ = of(results);
+      });
   }
 
   ngAfterViewInit(): void {
@@ -80,6 +84,7 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
   }
 
   search(term: string) {
+    this.loading = true;
     this.searchTerms.next(term);
   }
 


### PR DESCRIPTION
## Description

UX improvement

#### What does this PR do?

Before this change, the project list on the first DMP step showed nothing while projects were being fetched. The area was simply empty, which looks the same as having no results. This is especially noticeable on instances where the project service is slow, for example with the Elsevier Pure integration the recommended projects call can take several seconds because the backend pages through all projects before filtering.

Now an indeterminate progress bar is shown under the search field while the recommended projects load and while a search is running. It disappears as soon as results arrive.

This is independent of the configured project service, any instance benefits from it.

#### Breaking changes

None.

#### Code review focus

The loading flag is set in search() and cleared when the subscription receives results. MatProgressBarModule was already imported in the project module, so no module changes were needed.
<img width="725" height="234" alt="Screenshot 2026-08-25 at 09 35 16" src="https://github.com/user-attachments/assets/cff83da1-51a6-414a-a9b8-d2caeba4786c" />


#### Dependencies

None.

### Checks

- [ ] Summary updated (not applicable)
- [ ] Version view updated (not applicable)
- [ ] Tests added
- [x] Tested locally against a live Pure instance