### PR TITLE
People: Keep non-ORCID identifiers when editing a contributor

### DIFF
--- a/libs/damap/src/lib/components/dmp/people/people.component.ts
+++ b/libs/damap/src/lib/components/dmp/people/people.component.ts
@@ -138,9 +138,11 @@ export class PeopleComponent implements OnInit, OnDestroy {
       this.currentUpdateContributorIdx = -1;
     } else {
       this.currentUpdateContributorIdx = idx;
+      const personId = this.contributors.at(idx).value.personId;
       this.form.patchValue({
         mbox: this.contributors.at(idx).value.mbox,
-        personId: this.contributors.at(idx).value.personId.identifier,
+        personId:
+          personId?.type === IdentifierType.ORCID ? personId.identifier : '',
       });
     }
   }
@@ -155,13 +157,19 @@ export class PeopleComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const current = this.contributors.at(idx).value;
+    const orcid = this.form.value.personId;
+    let personId = current.personId;
+    if (orcid) {
+      personId = { identifier: orcid, type: IdentifierType.ORCID };
+    } else if (current.personId?.type === IdentifierType.ORCID) {
+      personId = null;
+    }
+
     const newContributor = {
-      ...this.contributors.at(idx).value,
+      ...current,
       mbox: this.form.value.mbox,
-      personId: {
-        identifier: this.form.value.personId,
-        type: IdentifierType.ORCID,
-      },
+      personId: personId,
       roles: this.form.value.roles,
     };
 


### PR DESCRIPTION
## Description

Bugfix

#### What does this PR do?

When editing a contributor inline in the People step, the form copied the contributor's identifier into the ORCID field regardless of its type. For contributors coming from Pure (or any person source that provides a non-ORCID identifier, stored with type OTHER) this had two effects:

- the Pure UUID was shown in a field labelled ORCID, which is misleading
- the UUID fails the ORCID validator, so the form was invalid and the Update button stayed disabled. Email and roles of such a contributor could not be edited at all

On top of that, updateContributorDetails always saved the identifier with type ORCID, so clearing the field to get past validation would have stored a wrongly typed identifier.

Now the ORCID field is only prefilled when the stored identifier actually is an ORCID. On save: if the user entered an ORCID it is used, if they cleared an existing ORCID it is removed, otherwise the original identifier (e.g. Pure UUID, type OTHER) is kept as is. This also fixes a crash when a contributor has no identifier at all (personId null).

Found by @sandaihu while testing the Pure integration at JKU.

#### Breaking changes

None.

#### Code review focus

The three-way decision in updateContributorDetails (entered ORCID / cleared ORCID / untouched non-ORCID id).

#### Dependencies

None.

### Checks

- [ ] Summary updated (not applicable)
- [ ] Version view updated (not applicable)
- [ ] Tests added
- [x] Built and checked locally